### PR TITLE
Add utf-8 encoding in latex log opening

### DIFF
--- a/gluon/contrib/markmin/markmin2pdf.py
+++ b/gluon/contrib/markmin/markmin2pdf.py
@@ -80,7 +80,7 @@ def latex2pdf(latex, pdflatex='pdflatex', passes=3):
             outfile.close()
         re_errors = re.compile('^\!(.*)$', re.M)
         re_warnings = re.compile('^LaTeX Warning\:(.*)$', re.M)
-        flog = open(logname)
+        flog = open(logname,encoding="utf-8")
         try:
             loglines = flog.read()
         finally:


### PR DESCRIPTION
By default, open use ascii encoding leading to crash when non ascii caracters are present . Fix it by enforcing UTF-8  encoding